### PR TITLE
Setup demo integration with GitLab

### DIFF
--- a/.gitlab/.gitlab-ci.yml
+++ b/.gitlab/.gitlab-ci.yml
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2024 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+stages:
+  - test
+  - report
+
+bastet:
+  image: python:3.12-slim
+  variables:
+    PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
+  cache:
+    paths:
+      - .cache/pip
+  before_script:
+    - pip install --editable '.[dev]'
+  script:
+    - bastet --skip format reuse --report note gitlab sonar
+  artifacts:
+    expose_as: 'Bastet Report'
+    name: 'bastet'
+    when: always
+    expire_in: "7 days"
+    reports:
+      codequality: "reports/code-climate.json"
+      junit:
+        - reports/junit-test.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: reports/coverage.xml
+    paths:
+      - reports
+
+sonarqube-check:
+  stage: report
+  when: always
+  image:
+    name: sonarsource/sonar-scanner-cli:5.0
+    entrypoint: [""]
+  variables:
+    SONAR_USER_HOME: "${CI_PROJECT_DIR}/.sonar"  # Defines the location of the analysis task cache
+    GIT_DEPTH: "0"  # Tells git to fetch all the branches of the project, required by the analysis task
+  cache:
+    key: "${CI_JOB_NAME}"
+    paths:
+      - .sonar/cache
+  needs:
+    - job: bastet
+      artifacts: true
+  script:
+    - sonar-scanner
+        -Dsonar.gitlab.commit_sha=$CI_COMMIT_SHA -Dsonar.gitlab.ref_name=$CI_COMMIT_REF_NAME
+        -Dsonar.gitlab.url=$CI_PROJECT_URL -Dsonar.gitlab.project_id=$CI_PROJECT_ID
+  allow_failure: true

--- a/README.md
+++ b/README.md
@@ -88,3 +88,9 @@ sonar.python.xunit.reportPaths=reports/junit-*.xml
 sonar.python.ruff.reportPaths=reports/ruff.txt
 sonar.python.pylint.reportPaths=reports/pylint.txt
 ```
+
+### Integration with Gitlab
+
+Bastet can produce up to three reports that GitLab can directly integrate into
+merge requests (code quality, test results, and coverage) using the `gitlab`
+reporter. A sample CI stage can be found in [`examples/gitlab-ci.yml`](examples/gitlab-ci.yml).

--- a/examples/gitlab-ci.yml
+++ b/examples/gitlab-ci.yml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2024 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+bastet:
+  image: python:3.12-slim
+  script:
+    - pip install --editable '.' bastet
+    # The reuse script has some issues in gitlab CI (https://github.com/mewbotorg/bastet/issues/2)
+    - bastet --skip format reuse --report note gitlab
+
+  variables:
+    PIP_CACHE_DIR: "${CI_PROJECT_DIR}/.cache/pip"
+  cache:
+    paths: [".cache/pip"]
+  artifacts:
+    name: 'bastet'
+    expose_as: 'Bastet Report'
+    when: always
+    paths:
+      - reports
+    reports:
+      codequality: "reports/code-climate.json"
+      junit:
+        - reports/junit-test.xml
+      coverage_report:
+        coverage_format: cobertura
+        path: reports/coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,6 @@ assert_used = {skips = ['*_test.py', '*test_*.py']}
 
 [tool.coverage]
 
-report = {fail_under=80.0}
 html = {show_contexts=true}
 
 [tool.coverage.run]

--- a/src/bastet/__main__.py
+++ b/src/bastet/__main__.py
@@ -20,6 +20,7 @@ import argparse
 import asyncio
 import logging
 import os
+import sys
 
 from . import BastetRunner, ReportHandler, config
 from .tools import Annotation
@@ -60,7 +61,8 @@ def main() -> None:
 
     # Build and run the async runner.
     runner = BastetRunner(options, reporter)
-    asyncio.run(runner.run())
+    results = asyncio.run(runner.run())
+    sys.exit(0 if results.success else 1)
 
 
 if __name__ == "__main__":

--- a/src/bastet/config.py
+++ b/src/bastet/config.py
@@ -295,7 +295,7 @@ class PathGatherer:  # pylint: disable=too-few-public-methods,too-many-instance-
     def _process_python_file(self, file: Path) -> None:
         self._python_files.add(file)
 
-        if self._add_path(self._python_module_path, file.parent):
+        if self._add_path(self._python_module_path, file.parent, remove_children=True):
             self.logger.debug("Marking %s as a module path", file.parent)
 
         if self._closest_relative(self._python_path, file):
@@ -325,7 +325,7 @@ class PathGatherer:  # pylint: disable=too-few-public-methods,too-many-instance-
         self._python_path.add(py_root)
 
     @staticmethod
-    def _add_path(paths: set[Path], path: Path) -> bool:
+    def _add_path(paths: set[Path], path: Path, *, remove_children: bool) -> bool:
         if path in paths:
             return False
 
@@ -333,7 +333,11 @@ class PathGatherer:  # pylint: disable=too-few-public-methods,too-many-instance-
             if path.is_relative_to(_path):
                 return False
 
+        if remove_children:
+            paths.difference_update({x for x in paths if x.is_relative_to(path)})
+
         paths.add(path)
+
         return True
 
     @staticmethod

--- a/src/bastet/reporting/__init__.py
+++ b/src/bastet/reporting/__init__.py
@@ -16,6 +16,7 @@ for machine or human consumption.
 from __future__ import annotations as _future_annotations
 
 from .abc import Reporter, ReportHandler
+from .codeclimate import CodeClimate
 from .console import AnnotationReporter
 from .file import FileReporter, SonarReporter
 from .github import GitHubReporter
@@ -25,6 +26,8 @@ reporters: dict[str, type[Reporter]] = {
     "note": AnnotationReporter,
     "file": FileReporter,
     "sonar": SonarReporter,
+    "codeclimate": CodeClimate,
+    "gitlab": CodeClimate,
 }
 
 

--- a/src/bastet/reporting/codeclimate.py
+++ b/src/bastet/reporting/codeclimate.py
@@ -1,0 +1,107 @@
+# SPDX-FileCopyrightText: 2024 Mewbot Developers <mewbot@quicksilver.london>
+#
+# SPDX-License-Identifier: BSD-2-Clause
+
+"""
+Formatter to export 'Code Climate' reports.
+
+These are also the codequality type reports in gitlab.
+"""
+
+from __future__ import annotations as _future_annotations
+
+from typing import Any
+
+import json
+import pathlib
+
+import bastet.tools.lint
+from bastet.tools import Annotation, Status, Tool, ToolDomain, ToolResults
+
+from .abc import Reporter, ReportInstance
+
+
+class CodeClimate(Reporter):
+    """
+    Formatter to export 'Code Climate' reports.
+
+    These are also the codequality type reports in gitlab.
+    """
+
+    async def create(self, _: Tool) -> ReportInstance | None:
+        """
+        CodeClimate does not report on tool runs, just a summary.
+        """
+
+    async def summarise(self, results: ToolResults) -> None:
+        """
+        Summarise all tool runs as a Code Climate report.
+
+        Each issue which is a Warning of higher is included in the report.
+        """
+
+        report = pathlib.Path("reports/code-climate.json")
+
+        with report.open("w", encoding="utf-8") as outfile:  # noqa: ASYNC101
+            json.dump(
+                list(
+                    map(
+                        self._issue_to_code_climate,
+                        filter(lambda a: a.status >= Status.WARNING, results.annotations),
+                    ),
+                ),
+                outfile,
+                indent=2,
+            )
+
+    def _issue_to_code_climate(self, annotation: Annotation) -> dict[str, Any]:
+        """
+        Convert an Annotation into a Code Climate Issue.
+
+        See https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#issues
+        """
+
+        tool = annotation.tool.name if annotation.tool else "bastet"
+        location = {
+            "path": annotation.filename,
+            "lines": {
+                "begin": annotation.source[1] or 1,
+                "end": annotation.source[1] or 1,
+            },
+        }
+        severity = "major"
+        categories: list[str] = []
+
+        if annotation.tool and annotation.tool.domain == ToolDomain.AUDIT:
+            categories.append("Security")
+        if isinstance(annotation.tool, bastet.tools.lint.MyPy):
+            categories.append("Bug Risk")
+        if "complexity" in annotation.message.lower():
+            categories.append("Complexity")
+        # This is not a typo, it's catching 'duplication' and 'duplicate'.
+        if "duplicat" in annotation.message.lower():
+            categories.append("Duplication")
+
+        if not categories:
+            categories = ["Style"]
+            severity = "minor"
+
+        issue = {
+            "type": "issue",
+            "check_name": f"{tool} :: {annotation.code}",
+            "severity": severity,
+            "fingerprint": "bastet-" + str(hash(annotation)),
+            "location": location,
+            "description": annotation.message,
+            "categories": categories,
+        }
+
+        if annotation.description:
+            issue["content"] = {"body": annotation.description}
+
+        return issue
+
+    async def close(self) -> None:
+        """
+        No close operation -- everything happens in summarise().
+        """


### PR DESCRIPTION
GitLab's Code Quality reporting uses a specific subset[2] of the Code Climate output[1]. Here we implement the sections of the full Code Climate spec we have easy access to, which includes all of the fields that GitLab requests.

A GitLab CI script has been added with unit test, coverage, code quality, and Sonar integrations demonstrated. The use of the reuse tool is disabled, as it was having unclear issues with believing the pip cache was part of the project.

A few minor bugs have also been quashed:
 - Prevented adding sub-modules as explicit base packages.
 - Add the creating Tool to annotations in the results processor.
 - Fix handling of streams when no Reporter requested any.
 - Exit with status code 1 is the run is not classified as a success.

[1] https://github.com/codeclimate/platform/blob/master/spec/analyzers/SPEC.md#issues
[2] https://docs.gitlab.com/ee/ci/testing/code_quality.html#implement-a-custom-tool