### PR TITLE
Improve defensive coding practices

### DIFF
--- a/src/bastet/__init__.py
+++ b/src/bastet/__init__.py
@@ -12,10 +12,10 @@ from .runner import BastetRunner, ReportHandler
 from .tools import Tool, ToolDomain, get_available_tools
 
 __all__ = [
-    "tools",
     "BastetRunner",
+    "ReportHandler",
     "Tool",
     "ToolDomain",
-    "ReportHandler",
     "get_available_tools",
+    "tools",
 ]

--- a/src/bastet/config.py
+++ b/src/bastet/config.py
@@ -64,7 +64,7 @@ class BastetConfiguration:  # pylint: disable=too-few-public-methods
 
         # Find the "root" of the repo (where the pyproject.toml should be).
         if args.root:
-            root_dir = Path().resolve()
+            root_dir = Path.cwd()
         else:
             logger.debug("Auto detecting repo root")
             root_dir = _find_pyproject(logger) or Path.cwd()

--- a/src/bastet/reporting/__init__.py
+++ b/src/bastet/reporting/__init__.py
@@ -32,7 +32,7 @@ reporters: dict[str, type[Reporter]] = {
 
 
 __all__ = [
-    "reporters",
     "ReportHandler",
     "Reporter",
+    "reporters",
 ]

--- a/src/bastet/reporting/codeclimate.py
+++ b/src/bastet/reporting/codeclimate.py
@@ -41,9 +41,12 @@ class CodeClimate(Reporter):
         Each issue which is a Warning of higher is included in the report.
         """
 
+        self._summarise(results)
+
+    def _summarise(self, results: ToolResults) -> None:
         report = pathlib.Path("reports/code-climate.json")
 
-        with report.open("w", encoding="utf-8") as outfile:  # noqa: ASYNC101
+        with report.open("w", encoding="utf-8") as outfile:
             json.dump(
                 list(
                     map(

--- a/src/bastet/runner.py
+++ b/src/bastet/runner.py
@@ -174,4 +174,4 @@ def gather_tools(domain: ToolDomain, config: BastetConfiguration) -> list[Tool]:
     ]
 
 
-__all__ = ["ReportHandler", "BastetRunner"]
+__all__ = ["BastetRunner", "ReportHandler"]

--- a/src/bastet/tools/test.py
+++ b/src/bastet/tools/test.py
@@ -56,7 +56,7 @@ class PyTest(Tool):
             f"--junit-xml={(self._paths.report_path / 'junit-test.xml')!s}",
             f"--cov-report=html:{self._paths.report_path!s}",
             f"--cov-report=xml:{(self._paths.report_path / 'coverage.xml')!s}",
-            *(f"--cov={module!s}" for module in self._paths.python_module_path),
+            "--cov=.",
         ]
 
     def get_environment(self) -> dict[str, str]:
@@ -129,11 +129,11 @@ def _get_testcase_source(test_class: str, test_name: str) -> tuple[str, int, int
     try:
         # Assume we're looking at a function in a module.
         module = importlib.import_module(test_class)
-    except ImportError:
+    except (ImportError, ValueError):
         try:
             mod, _, test_class = test_class.rpartition(".")
             module = importlib.import_module(mod)
-        except ImportError:
+        except (ImportError, ValueError):
             return None
 
         if test_class not in module.__dict__:

--- a/src/bastet/tools/tool.py
+++ b/src/bastet/tools/tool.py
@@ -376,7 +376,7 @@ class Annotation:
     description: str | None
     diff: list[str] | None
 
-    def __init__(  # pylint: disable=R0913 # noqa: PLR0913 - 6 args is "ok" here.
+    def __init__(  # pylint: disable=R0917,R0913
         self,
         status: Status,
         source: tuple[pathlib.Path | str, int | None, int | None] | pathlib.Path | str | None,

--- a/tests/bastet/tests/test_annotations.py
+++ b/tests/bastet/tests/test_annotations.py
@@ -11,6 +11,7 @@ from __future__ import annotations as _future_annotations
 import pathlib
 
 import pytest
+
 from bastet.tools import Annotation, Status
 
 from .util import ParameterSet


### PR DESCRIPTION
- Handle the case where jUnit information does not resolve to a valid module name
- Handle arbitrary exceptions in Tool.process_results as a ToolError